### PR TITLE
remove typo'ed, expired copyright.

### DIFF
--- a/tools/altperl/slonik_drop_sequence.pl
+++ b/tools/altperl/slonik_drop_sequence.pl
@@ -2,7 +2,6 @@
 #
 # Author: Mark Stosberg
 # Based on work by: Christopher Browne
-# Parts Copyright 2008 Summerault, LLC
 # Parts Copyright 2004-2009 Afilias Canada
 
 use Getopt::Long;

--- a/tools/altperl/slonik_drop_table.pl
+++ b/tools/altperl/slonik_drop_table.pl
@@ -2,7 +2,6 @@
 #
 # Author: Mark Stosberg
 # Based on work by: Christopher Browne
-# Parts Copyright 2006 Summerault, LLC
 # Parts Copyright 2004-2009 Afilias Canada
 
 use Getopt::Long;

--- a/tools/altperl/slonik_print_preamble.pl
+++ b/tools/altperl/slonik_print_preamble.pl
@@ -2,7 +2,6 @@
 #
 # Author: Mark Stosberg
 # Based on work by: Christopher Browne
-# Parts Copyright 2006 Summerault, LLC
 # Parts Copyright 2004-2009 Afilias Canada
 
 use Getopt::Long;


### PR DESCRIPTION
I wrote these utilities back in 2006-2008.

There was a typo in the company name, which should have been "Summersault, LLC".

However, that company no longer exists: http://www.summersault.com

To simplify any future copyright concerns for the project, I'm just
removing the copyright statement rather than fix the typo.