### PR TITLE
Fix build failure with PG15: Remove utils/int8.h

### DIFF
--- a/src/backend/slony1_funcs.c
+++ b/src/backend/slony1_funcs.c
@@ -44,7 +44,6 @@
 #include "utils/memutils.h"
 #include "utils/hsearch.h"
 #include "utils/timestamp.h"
-#include "utils/int8.h"
 #ifdef HAVE_GETACTIVESNAPSHOT
 #include "utils/snapmgr.h"
 #endif


### PR DESCRIPTION
PG15 removes this header, and it doesn't seem necessary on PG10 either, so remove it unconditionally.

@wieck: This is the build problem I mentioned at pgconf.eu.