### PR TITLE
Match size of STMTS in scanner.c

### DIFF
--- a/src/parsestatements/test-scanner.c
+++ b/src/parsestatements/test-scanner.c
@@ -3,7 +3,7 @@
 #include "scanner.h"
 
 char		foo[65536];
-extern int	STMTS[1024];
+extern int	STMTS[MAXSTATEMENTS];
 extern int	statements;
 
 int


### PR DESCRIPTION
Fix #21 
Match the size of the declared array
